### PR TITLE
【Add】TheCatApiの実装03（TypeScriptで型を指定する実装）

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,8 +5,15 @@ import styles from '@/styles/Home.module.css'
 
 const inter = Inter({ subsets: ['latin'] })
 
+interface SearchCatImage {
+  id: string;
+  url: string;
+  width: number;
+  height: number;
+}
+
 export default function Home() {
-  const fetchCatImage = async () => {
+  const fetchCatImage = async (): Promise<SearchCatImage> => {
     const res = await fetch("https://api.thecatapi.com/v1/images/search");
     const result = await res.json();
     // console.log(result[0]);
@@ -15,7 +22,7 @@ export default function Home() {
 
   const handleClick = async () => {
     const catImage = await fetchCatImage();
-    console.log(catImage);
+    console.log(catImage.url);
   };
 
   return (


### PR DESCRIPTION
- [x] 【Add】TheCatApiの実装03（TypeScriptで型を指定する実装）
  - [x] `interface`で`SearchCatImage`を定義
  - [x] `fetchCatImage`関数に`Promise`メソッドで`SearchCatImage`を指定
  - [x] `console.log`で取得する対象をURLだけに指定