### PR TITLE
【Add】TheCatApiの実装05（SSRでリロード時のAPI実行機能を実装）

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image'
 import { Inter } from 'next/font/google'
 import styles from '@/styles/Home.module.css'
 import { useState } from 'react'
+import { GetServerSideProps, NextPage } from 'next'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -13,14 +14,19 @@ interface SearchCatImage {
   height: number;
 }
 
-export default function Home() {
-  const [catImageUrl, setCatImageUrl] = useState("");
-  const fetchCatImage = async (): Promise<SearchCatImage> => {
-    const res = await fetch("https://api.thecatapi.com/v1/images/search");
-    const result = await res.json();
-    // console.log(result[0]);
-    return result[0];
-  };
+interface IndexPageProps {
+  initialCatImageUrl: string;
+}
+
+const fetchCatImage = async (): Promise<SearchCatImage> => {
+  const res = await fetch("https://api.thecatapi.com/v1/images/search");
+  const result = await res.json();
+  // console.log(result[0]);
+  return result[0];
+};
+
+const Home: NextPage<IndexPageProps> = ( {initialCatImageUrl} ) => {
+  const [catImageUrl, setCatImageUrl] = useState(initialCatImageUrl);
 
   const handleClick = async () => {
     const catImage = await fetchCatImage();
@@ -36,5 +42,19 @@ export default function Home() {
         今日の猫さん
       </button>
     </div>
-  );
+  );  
 };
+
+// SSR
+export const getServerSideProps: GetServerSideProps<
+  IndexPageProps
+> = async () => {
+  const catImage = await fetchCatImage();
+  return {
+    props: {
+      initialCatImageUrl: catImage.url,
+    },
+  };
+};
+
+export default Home;


### PR DESCRIPTION
- [x] TheCatApiの実装05（SSRでリロード時のAPI実行機能を実装）
  - [x] SSRで`getServerSideProps `関数を実装
  - [x] `IndexPageProps`に命名した`interface`を実装
  - [x] `Home`関数コンポーネントをアロー関数表記に変更
  - [x] `Home`関数コンポーネントに`initialCatImageUrl`を指定し、リロード時にAPIが呼び出されるように実装
  - [x] `index.tsx`の最下部に`export default Home;`を追記